### PR TITLE
Fix for NullPointerException on non-static fields

### DIFF
--- a/src/main/java/com/ajitgeorge/flags/Flags.java
+++ b/src/main/java/com/ajitgeorge/flags/Flags.java
@@ -160,7 +160,7 @@ public class Flags {
         try {
             return field.get(null);
         } catch (NullPointerException e) {
-            throw new RuntimeException("Field " + field.getName() + " cannot be accessed statically", e);
+            throw new IllegalAccessException();
         }
     }
 

--- a/src/test/java/com/ajitgeorge/flags/properties/Properties.java
+++ b/src/test/java/com/ajitgeorge/flags/properties/Properties.java
@@ -6,6 +6,9 @@ import java.math.BigDecimal;
 
 public class Properties {
 
+    @Flag("bogus")
+    public String bogusFlag = "totally";
+
     @Flag("string")
     public static String stringFlag = "default";
 


### PR DESCRIPTION
field.get(null) throws NPE on non-static fields not the expected IllegalAccessException
